### PR TITLE
fix: fix code pre bg color conflict with git comment plugin

### DIFF
--- a/source/css/highlight.css
+++ b/source/css/highlight.css
@@ -24,7 +24,7 @@
     width: 100%;
     padding-left: 10px;
     padding-right: 10px;
-    background-color: #2d2d2d;
+    background-color: #2d2d2d !important;
 }
 
 .markdown-body .highlight table tbody pre {


### PR DESCRIPTION
I found that when I enable the gitalk plugin, the markdown pre background changes to white, this PR's purpose is to fix that problem, [issue](https://github.com/zchengsite/hexo-theme-oranges/issues/5)
problem:
![image](https://user-images.githubusercontent.com/15920861/93694595-56be1d00-fb40-11ea-80d3-576d393b7434.png)
![image](https://user-images.githubusercontent.com/15920861/93694540-87518700-fb3f-11ea-8a72-4e2100e82bd2.png)
![image](https://user-images.githubusercontent.com/15920861/93694544-96d0d000-fb3f-11ea-84ab-279a8a33fcc8.png)

fixed:
![image](https://user-images.githubusercontent.com/15920861/93694589-3d1cd580-fb40-11ea-9981-b577ae63621d.png)

