### PR TITLE
fix: relative search url

### DIFF
--- a/layout/_partial/search.ejs
+++ b/layout/_partial/search.ejs
@@ -130,7 +130,7 @@
               }
               // 0x05. show search results
               if (isMatch) {
-                str += "<li><a href='" + data_url + "' class='search-result-title'>" + orig_data_title + "</a>";
+                str += "<li><a href='/" + data_url + "' class='search-result-title'>" + orig_data_title + "</a>";
                 var content = orig_data_content;
                 if (first_occur >= 0) {
                   // cut out 100 characters


### PR DESCRIPTION
first, thanks for making the awesome theme!

![search_url](https://user-images.githubusercontent.com/8168124/96663914-ac2e5980-138c-11eb-8298-bb2280dc2151.png)

btw, i found that search result url takes me to a non-existing page instead of the result post page when i'm in a post page (it works fine in main page)

i don't know much about how web url works but
i think `href=/something` is equivalent to `host_name + something` while `href=something` is equivalent to `current_url + something`

adding '/' to front of data_url in search.ejs:133 will resolve the problem for me.

please take a look and let me know what you think!
