### PR TITLE
Update footer.ejs

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -12,7 +12,11 @@
   </div>
   <% for(let item of theme.footer.more){ %>
     <div class="footer-more">
-      <a href="<%- item.path %>"><%- item.name %></a>
+      <% if (item.path) { %>
+        <a href="<%- item.path %>"><%- item.name %></a>
+      <% } else { %>
+        <%- item.name %>
+      <% } %>  
     </div>
   <% } %>
 </div>


### PR DESCRIPTION
Allow users to disable path for foot-more in _config.yaml. The footnotes without paths will be presented as plain texts.