### PR TITLE
更新使用说明

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -2,35 +2,39 @@
 
 # hexo-theme-oranges
 
-> 一个简单的hexo主题
+> 一个简单的 hexo 主题
 
 [demo](https://hexo.theme.oranges.zcheng.site/)
 
 ## 安装
 
-在hexo博客项目根目录下执行，会将`oranges`主题clone至`themes`文件夹下
+为了更为便捷的更新主题，建议使用添加 Git 子模块的方法安装，在 hexo 博客项目根目录下执行，会将`oranges`主题 clone 至`themes`文件夹下。
 
 ```bash
-$ git clone https://github.com/zchengsite/hexo-theme-oranges.git themes/oranges
+git submodule add https://github.com/zchengsite/hexo-theme-oranges.git themes/oranges
 ```
+
+日后更新主题只需要在主题根目录执行`git pull`命令即可。
 
 ## 使用
 
-在hexo博客项目根目录下找到`_config.yml`文件，修改其中`theme`字段为主题名`oranges`
+在 hexo 博客项目根目录下找到`_config.yml`文件，修改其中`theme`字段为主题名`oranges`
 
 ```yml
 theme: oranges
 ```
+
+复制主题文件夹下的`_config.yml`文件到博客根目录并改名为`_config.oranges.yml`，后续修改主题操作均在`_config.oranges.yml`中进行。
 
 ## 配置
 
 <details>
   <summary><b>Tags page</b> (click to show)</summary>
 
-在hexo博客项目根目录下执行，在`source`文件夹下生成`tags`文件夹
+在 hexo 博客项目根目录下执行，在`source`文件夹下生成`tags`文件夹
 
 ```bash
-$ hexo new page tags
+hexo new page tags
 ```
 
 接着修改`tags`文件夹下`index`为以下内容
@@ -45,7 +49,7 @@ tags:
 ---
 ```
 
-并在主题配置文件`_config.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
+并在配置文件`_config.oranges.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
 
 ```yml
 navbar:
@@ -60,10 +64,10 @@ navbar:
 <details>
   <summary><b>Friends page</b> (click to show)</summary>
 
-在hexo博客项目根目录下执行，在`source`文件夹下生成`friends`文件夹
+在 hexo 博客项目根目录下执行，在`source`文件夹下生成`friends`文件夹
 
 ```bash
-$ hexo new page friends
+hexo new page friends
 ```
 
 接着修改`friends`文件夹下`index`为以下内容
@@ -78,7 +82,7 @@ tags:
 ---
 ```
 
-并在主题配置文件`_config.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
+并在配置文件`_config.oranges.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
 
 ```yml
 navbar:
@@ -87,15 +91,16 @@ navbar:
     enable: true
     path: /friends/
 ```
+
 </details>
 
 <details>
   <summary><b>About me page</b> (click to show)</summary>
 
-在hexo博客项目根目录下执行，在`source`文件夹下生成`about`文件夹
+在 hexo 博客项目根目录下执行，在`source`文件夹下生成`about`文件夹
 
 ```bash
-$ hexo new page about
+hexo new page about
 ```
 
 接着修改`about`文件夹下`index`为以下内容
@@ -110,7 +115,7 @@ tags:
 ---
 ```
 
-并在主题配置文件`_config.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
+并在配置文件`_config.oranges.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
 
 ```yml
 navbar:
@@ -125,10 +130,10 @@ navbar:
 <details>
   <summary><b>Categories page</b> (click to show)</summary>
 
-在hexo博客项目根目录下执行，在`source`文件夹下生成`categories`文件夹
+在 hexo 博客项目根目录下执行，在`source`文件夹下生成`categories`文件夹
 
 ```bash
-$ hexo new page categories
+hexo new page categories
 ```
 
 接着修改`categories`文件夹下`index`为以下内容
@@ -143,7 +148,7 @@ tags:
 ---
 ```
 
-并在主题配置文件`_config.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
+并在配置文件`_config.oranges.yml`修改对应`enable`为`true`，如不想展示，设置为`false`即可
 
 ```yml
 navbar:
@@ -156,9 +161,9 @@ navbar:
 </details>
 
 <details>
-  <summary><b>文章目录(Catalog)</b> (click to show)</summary>
+  <summary><b>文章目录 (Catalog)</b> (click to show)</summary>
 
-主题配置文件`_config.yml`下`catalog`修改`enable`为`true`，如不想展示，设置为`false`即可
+在配置文件`_config.oranges.yml`下`catalog`修改`enable`为`true`，如不想展示，设置为`false`即可
 
 ```yml
 catalog:
@@ -173,10 +178,10 @@ catalog:
 1.安装`hexo-generator-feed`[官方插件](https://github.com/hexojs/hexo-generator-feed)
 
 ```shell
-$ npm install hexo-generator-feed --save
+npm install hexo-generator-feed --save
 ```
 
-2.在博客项目配置文件`_config.yml`(非主题配置文件)增加:
+2.在博客项目配置文件`_config.yml`(非主题配置文件) 增加：
 
 ```yml
 feed:
@@ -193,8 +198,8 @@ feed:
   template:
 ```
 
-3.开启rss按钮
-在主题配置文件`_config.yml`增加页脚项:
+3.开启 rss 按钮
+在配置文件`_config.oranges.yml`增加页脚项：
 
 ```yml
 footer:
@@ -208,14 +213,15 @@ footer:
 </details>
 
 <details>
-  <summary><b>评论系统(Comment)</b> (click to show)</summary>
+  <summary><b>评论系统 (Comment)</b> (click to show)</summary>
 
-1.确保主题配置文件`_config.yml`下`comments`->`enable: true`
+1.确保配置文件`_config.oranges.yml`下`comments`->`enable: true`
 
 2.目前支持以下几种评论插件
-  - [valine](https://valine.js.org/quickstart.html)
-  - [gitalk](https://github.com/gitalk/gitalk#usage)
-  - [disqus](https://disqus.com)(需科学上网)
+
+- [valine](https://valine.js.org/quickstart.html)
+- [gitalk](https://github.com/gitalk/gitalk#usage)
+- [disqus](https://disqus.com)(需科学上网)
 
 3.如需使用，修改相应评论下`enable: true`
 
@@ -241,8 +247,8 @@ comments:
   <summary><b>Google Analytics</b> (click to show)</summary>
 
 [Google Analytics](https://analytics.google.com)
-注册Google分析账号，在管理/创建媒体资源/选择网站/填写相关信息后得到跟踪Id，一般格式为UA-xxxxxxx-x
-如之前已有注册账号，在管理/跟踪信息/跟踪代码/找到跟踪ID，一般格式为UA-xxxxxxx-x
+注册 Google 分析账号，在管理/创建媒体资源/选择网站/填写相关信息后得到跟踪 Id，一般格式为 UA-xxxxxxx-x
+如之前已有注册账号，在管理/跟踪信息/跟踪代码/找到跟踪 ID，一般格式为 UA-xxxxxxx-x
 
 ```yml
 gtag:
@@ -265,12 +271,12 @@ prevnext:
 </details>
 
 <details>
-  <summary><b>文章图片懒加载(Lazy image loading)</b> (click to show)</summary>
+  <summary><b>文章图片懒加载 (Lazy image loading)</b> (click to show)</summary>
 
 安装插件[hexo-lazyload-image](https://github.com/Troy-Yang/hexo-lazyload-image)
 
 ```bash
-$ npm install hexo-lazyload-image --save
+npm install hexo-lazyload-image --save
 ```
 
 项目配置文件`_config.yml`（非主题配置文件）下添加：
@@ -288,12 +294,12 @@ lazyload:
 </details>
 
 <details>
-  <summary><b>全文搜索(search)</b> (click to show)</summary>
+  <summary><b>全文搜索 (search)</b> (click to show)</summary>
 
   1.安装插件[hexo-generator-search](https://github.com/wzpan/hexo-generator-search)
 
   ```bash
-  $ npm install hexo-generator-search --save
+  npm install hexo-generator-search --save
   ```
 
   2.项目配置文件`_config.yml`（非主题配置文件）下添加：
@@ -319,13 +325,13 @@ lazyload:
 </details>
 
 <details>
-  <summary><b>文章置顶(pinned posts)</b> (click to show)</summary>
+  <summary><b>文章置顶 (pinned posts)</b> (click to show)</summary>
 
   1.安装插件[hexo-generator-index-pin-top](https://github.com/netcan/hexo-generator-index-pin-top)。
 
   ```bash
-  $ npm uninstall hexo-generator-index --save
-  $ npm install hexo-generator-index-pin-top --save
+  npm uninstall hexo-generator-index --save
+  npm install hexo-generator-index-pin-top --save
   ```
 
   2.项目配置文件`_config.yml`（非主题配置文件）下添加（如已有请忽略）：
@@ -339,7 +345,7 @@ lazyload:
 
   详情可见[hexo-generator-index-pin-top](https://github.com/netcan/hexo-generator-index-pin-top)。
 
-  3.在所需置顶的文章front-matter头中添加`top: true`即可：
+  3.在所需置顶的文章 front-matter 头中添加`top: true`即可：
 
   ```markdown
   ---
@@ -349,29 +355,35 @@ lazyload:
   tags:
   - Welcome
   categories:
-  - [Welcome, 欢迎]
+  - [Welcome，欢迎]
 ---
   ```
+
   4.重启服务后，可在主页文章标题看到置顶图标。
 
 </details>
 
 <details>
-  <summary><b>国际化(i18n)</b> (click to show)</summary>
+  <summary><b>国际化 (i18n)</b> (click to show)</summary>
 
   现在页面部分元素支持以不同语言显示，通过修改项目配置文件`_config.yml`（非主题配置文件）中的`language`:
 
   举几个例子：
   
   英文：
+
   ```yml
   language: en
   ```
+
   中文：
+
   ```yml
   language: zh-CN
   ```
+
   日文：
+
   ```yml
   language: ja
   ```
@@ -383,7 +395,7 @@ lazyload:
 <details>
   <summary><b>主题配色切换</b> (click to show)</summary>
 
-  拉取最新仓库，在主题配置文件`_config.yml`中添加或修改`colorSwitch`字段，确保`enable`为`true`:
+  拉取最新仓库，在配置文件`_config.oranges.yml`中添加或修改`colorSwitch`字段，确保`enable`为`true`:
 
   ```yml
   colorSwitch:
@@ -397,7 +409,7 @@ lazyload:
 <details>
   <summary><b>文章分享</b> (click to show)</summary>
 
-  拉取最新仓库，在主题配置文件`_config.yml`中添加或修改`postShare`字段，确保`enable`为`true`:
+  拉取最新仓库，在配置文件`_config.oranges.yml`中添加或修改`postShare`字段，确保`enable`为`true`:
 
   ```yml
   postShare:
@@ -414,13 +426,13 @@ lazyload:
 <details>
   <summary><b>文章加密</b> (click to show)</summary>
 
-  拉取最新仓库代码, 安装[hexo-blog-encrypt](https://github.com/D0n9X1n/hexo-blog-encrypt) 插件：
+  拉取最新仓库代码，安装[hexo-blog-encrypt](https://github.com/D0n9X1n/hexo-blog-encrypt) 插件：
 
   ```bash
-  $ npm install --save hexo-blog-encrypt
+  npm install --save hexo-blog-encrypt
   ```
 
-  在你要加密文章头部 Front-matter中添加password：
+  在你要加密文章头部 Front-matter 中添加 password：
 
   ```yml
     ---
@@ -440,18 +452,18 @@ lazyload:
 ## To Do List
 
 - [x] 自定义导航，可灵活配置自己想要的导航✔
-- [x] toc文章目录展示✔
+- [x] toc 文章目录展示✔
   - [x] 优化超出屏幕部分滚动显示，并自动跟随文章内容滚动`[2020.5.24]`✔
 - [x] Fancybox，支持文章内图片友好浏览✔
 - [x] 回到页面顶部`[2020.5.4]`✔
 - [x] RSS Feed`[2020.5.7]`✔
-- [x] 文章页末增加NEXT & PREV`[2020.5.10]`✔
+- [x] 文章页末增加 NEXT & PREV`[2020.5.10]`✔
 - [x] 文章标题锚点`[2020.5.3]`✔
 - [x] 评论系统`[2020.5.7]`✔
 - [x] 分享功能`[2021.8.22]`✔
 - [ ] 文章字数统计
 - [ ] 页面访问量统计
-- [x] Google分析`[2020.5.8]`✔
+- [x] Google 分析`[2020.5.8]`✔
 - [x] 文章加密`[2022.3.23]`✔
 - [x] 文章置顶`[2020.9.1]`✔
 - [x] 全文搜索功能`[2020.8.23]`✔
@@ -462,9 +474,9 @@ lazyload:
 
 ## End
 
-有问题请提交Issue，欢迎Fork。
+有问题请提交 Issue，欢迎 Fork。
 
-如果觉得主题还不错，请点击Star支持下。
+如果觉得主题还不错，请点击 Star 支持下。
 
 🍻
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,20 @@ English | [简体中文](https://github.com/zchengsite/hexo-theme-oranges/blob/m
 ## Installation
 
 ```bash
-$ git clone https://github.com/zchengsite/hexo-theme-oranges.git themes/oranges
+git submodule add https://github.com/zchengsite/hexo-theme-oranges.git themes/oranges
 ```
+
+To update the theme in the future, just execute the `git pull` command in the theme root directory.
 
 ## Usage
 
-Edit the `theme` field in the `_config.yml` file under the project root:
+In order to update the theme more conveniently, it is recommended to install it by adding a Git submodule.Edit the `theme` field in the `_config.yml` file under the project root:
 
 ```yml
 theme: oranges
 ```
+
+Copy the `_config.yml` file in the theme folder to the blog root directory and rename it to `_config.oranges.yml`. Subsequent theme modification operations are performed in `_config.oranges.yml`.
 
 ## configuration
 
@@ -28,7 +32,7 @@ theme: oranges
   To add `tags page`:
 
   ```bash
-  $ hexo new page tags
+  hexo new page tags
   ```
 
   Generate `tags` folder, edit the `index.md` file, make sure that `type` field is `tags`:
@@ -41,7 +45,7 @@ theme: oranges
   ---
   ```
 
-  Enable `tags` in the theme `_config.yml` file:
+  Enable `tags` in the `_config.oranges.yml` file:
 
   ```yml
   navbar:
@@ -59,7 +63,7 @@ theme: oranges
   To add `categories page`:
 
   ```bash
-  $ hexo new page categories
+  hexo new page categories
   ```
 
   Generate `categories` folder, edit the `index.md` file, make sure that `type` field is `categories`:
@@ -72,7 +76,7 @@ theme: oranges
   ---
   ```
 
-  Enable `categories` in the theme `_config.yml` file:
+  Enable `categories` in the `_config.oranges.yml` file:
 
   ```yml
   navbar:
@@ -90,7 +94,7 @@ theme: oranges
   To add `friends page`:
 
   ```bash
-  $ hexo new page friends
+  hexo new page friends
   ```
 
   Generate `friends` folder, edit the `index.md` file, make sure that `type` field is `friends`:
@@ -103,7 +107,7 @@ theme: oranges
   ---
   ```
 
-  Enable `friends` in the theme `_config.yml` file:
+  Enable `friends` in the `_config.oranges.yml` file:
 
   ```yml
   navbar:
@@ -121,7 +125,7 @@ theme: oranges
   To add `about page`:
 
   ```bash
-  $ hexo new page about
+  hexo new page about
   ```
 
   Generate `about` folder, edit the `index.md` file, make sure that `type` field is `about`:
@@ -134,7 +138,7 @@ theme: oranges
   ---
   ```
 
-  Enable `about` in the theme `_config.yml` file:
+  Enable `about` in the `_config.oranges.yml` file:
 
   ```yml
   navbar:
@@ -149,7 +153,7 @@ theme: oranges
 <details>
   <summary><b>catalog(contents)</b> (click to show)</summary>
 
-  Enable `catalog` in the theme `_config.yml` file:
+  Enable `catalog` in the `_config.oranges.yml` file:
 
   ```yml
   catalog:
@@ -164,7 +168,7 @@ theme: oranges
   Install the `hexo-generator-feed` [plugin](https://github.com/hexojs/hexo-generator-feed):
 
   ```bash
-  $ npm install hexo-generator-feed --save
+  npm install hexo-generator-feed --save
   ```
 
   add or edit configuration in your root `_config.yml`:
@@ -202,11 +206,11 @@ theme: oranges
 
   supported:
 
-  - [valine](https://valine.js.org/quickstart.html)
-  - [gitalk](https://github.com/gitalk/gitalk#usage)
-  - [disqus](https://disqus.com)
+- [valine](https://valine.js.org/quickstart.html)
+- [gitalk](https://github.com/gitalk/gitalk#usage)
+- [disqus](https://disqus.com)
 
-  First, Enable `Comments` in the theme `_config.yml` file:
+  First, Enable `Comments` in the `_config.oranges.yml` file:
 
   ```yml
   comments:
@@ -233,7 +237,7 @@ theme: oranges
 
   First, view [Google Analytics](https://analytics.google.com) to get the `gtagkey`:
 
-  Then, enable `gtag` in the theme `_config.yml` file:
+  Then, enable `gtag` in the `_config.oranges.yml` file:
 
   ```yml
   gtag:
@@ -246,7 +250,7 @@ theme: oranges
 <details>
   <summary><b>PREV & NEXT</b> (click to show)</summary>
 
-  enable `prevnext` in the theme `_config.yml` file:
+  enable `prevnext` in the `_config.oranges.yml` file:
 
   ```yml
   prevnext:
@@ -261,7 +265,7 @@ theme: oranges
   Install the [hexo-lazyload-image](https://github.com/Troy-Yang/hexo-lazyload-image) plugin:
 
   ```bash
-  $ npm install hexo-lazyload-image --save
+  npm install hexo-lazyload-image --save
   ```
 
   add or edit configuration in your root `_config.yml`:
@@ -284,7 +288,7 @@ theme: oranges
   Install [hexo-generator-search](https://github.com/wzpan/hexo-generator-search) plugin:
 
   ```bash
-  $ npm install hexo-generator-search --save
+  npm install hexo-generator-search --save
   ```
 
   add or edit configuration in your root `_config.yml`:
@@ -298,7 +302,7 @@ theme: oranges
 
   more [hexo-generator-search](https://github.com/wzpan/hexo-generator-search)
 
-  edit configuration in the theme `_config.yml`
+  edit configuration in the `_config.oranges.yml`
 
   ```yml
     search:
@@ -314,8 +318,8 @@ theme: oranges
   Remove default `hexo-generator-index` and Install the [hexo-generator-index-pin-top](https://github.com/netcan/hexo-generator-index-pin-top) plugin:
 
   ```bash
-  $ npm uninstall hexo-generator-index --save
-  $ npm install hexo-generator-index-pin-top --save
+  npm uninstall hexo-generator-index --save
+  npm install hexo-generator-index-pin-top --save
   ```
 
   add or edit configuration in your root `_config.yml`:
@@ -353,14 +357,19 @@ theme: oranges
   Some examples:
 
   English:
+
   ```yml
   language: en
   ```
+
   Simplified Chinese:
+
   ```yml
   language: zh-CN
   ```
+
   Japanese:
+
   ```yml
   language: ja
   ```
@@ -372,7 +381,7 @@ theme: oranges
 <details>
   <summary><b>dark mode</b> (click to show)</summary>
 
-  Pull up the latest repository, add or edit configuration in theme `_config.yml`:
+  Pull up the latest repository, add or edit configuration in `_config.oranges.yml`:
 
   ```yml
   colorSwitch:
@@ -386,7 +395,7 @@ The toggle option appears in the bottom right corner of the page.
 <details>
   <summary><b>share</b> (click to show)</summary>
 
-  Pull up the latest repository, add or edit configuration in theme `_config.yml`:
+  Pull up the latest repository, add or edit configuration in `_config.oranges.yml`:
 
   ```yml
   postShare:
@@ -406,7 +415,7 @@ The toggle option appears in the bottom right corner of the post page.
   install the [hexo-blog-encrypt](https://github.com/D0n9X1n/hexo-blog-encrypt) plugin:
 
   ```bash
-  $ npm install --save hexo-blog-encrypt
+  npm install --save hexo-blog-encrypt
   ```
 
   add or edit Front-matter in your post:

--- a/_config.yml
+++ b/_config.yml
@@ -139,36 +139,38 @@ footer:
     # name: 名称
     # icon: 图标，目前仅支持IconFont部分图标
     # path: 地址
-    -
-      name: github
-      icon: github
-      path: https://github.com/zchengsite/hexo-theme-oranges
-    -
-      name: email
-      icon: envelope
-      path: 
-    -
-      name: facebook
-      icon: facebooksquare
-      path:
-    -
-      name: twitter
-      icon: twitter
-      path:
-    -
-      name: wechat
-      icon: wechat
-      path:
-    -
-      name: weibo
-      icon: weibo
-      path:
-    -
-      # rss需安装 hexo-generator-feed 插件
-      # 具体参照https://github.com/hexojs/hexo-generator-feed
-      name: rss
-      icon: rss
-      path: /atom.xml
+
+    # 按需取消注释以启用
+    # -
+    #   name: github
+    #   icon: github
+    #   path: https://github.com/zchengsite/hexo-theme-oranges
+    # -
+    #   name: email
+    #   icon: envelope
+    #   path: 
+    # -
+    #   name: facebook
+    #   icon: facebooksquare
+    #   path:
+    # -
+    #   name: twitter
+    #   icon: twitter
+    #   path:
+    # -
+    #   name: wechat
+    #   icon: wechat
+    #   path:
+    # -
+    #   name: weibo
+    #   icon: weibo
+    #   path:
+    # -
+    #   # rss需安装 hexo-generator-feed 插件
+    #   # 具体参照https://github.com/hexojs/hexo-generator-feed
+    #   name: rss
+    #   icon: rss
+    #   path: /atom.xml
 
   more:
     # 支持变量显示，可自定义扩展，具体见主题/layout/_partial/footer.ejs


### PR DESCRIPTION
通过添加 Git 子模块的方法安装主题，并且根据[Hexo 5.0.0](https://hexo.io/zh-cn/docs/configuration) 的新特性来配置主题，优化README文件的排版。

修改 `_config.yml` 的原因：由于主题内部 `_config.yml` 的底部社交图标都开启的情况下， `_config.oranges.yaml` 只配置少于主题内部 `_config.yml` 的图标，就会造成主题内部 `_config.yml` 的图标继续补充在底部，所以设置为全部关闭，按需开启。