### PR TITLE
feat: header metadata

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -1,13 +1,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <% if (page.keywords){ %>
-  <meta name="keywords" content="<%= page.keywords %>,<%= config.keywords %>">
-  <% } else if (config.keywords){ %>
-  <meta name="keywords" content="<%= config.keywords %>">
-  <%} %>
   <meta name="author" content="<%= config.author %>" />
-  <meta name="description" content="<%= config.description %>" />
+  <% if (page.description){ %>
+    <!-- 文章页 -->
+    <meta name="description" content="<%= page.description %>" />
+  <% } else if (config.description){ %>
+    <meta name="description" content="<%= config.description %>" />
+  <%} %>
   <% if(is_home() && page.current > 1){ %>
     <meta name="robots" content="noindex" />
   <% } %>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -2,11 +2,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="author" content="<%= config.author %>" />
+  <!-- Open Graph Description 简短摘要-->
+  <% if (page.ogdescription){ %>
+  <!-- 文章页 -->
+  <meta property="og:description" content="<%= page.ogdescription %>" />
+  <% } %>
+  <!-- 用于搜索引擎的文章摘要 -->
   <% if (page.description){ %>
-    <!-- 文章页 -->
-    <meta name="description" content="<%= page.description %>" />
+  <!-- 文章页 -->
+  <meta name="description" content="<%= page.description %>" />
   <% } else if (config.description){ %>
-    <meta name="description" content="<%= config.description %>" />
+  <meta name="description" content="<%= config.description %>" />
   <%} %>
   <% if(is_home() && page.current > 1){ %>
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
1. 移除 meta keywords 字段：[现代搜索引擎不再支持 meta keywords 字段](https://blog.skk.moe/post/say-no-to-meta-keywords/)。如 [Google](https://developers.google.com/search/docs/crawling-indexing/special-tags#unsupported)。
2. 当文章或单页提供了 `description` 时覆盖站点配置文件的描述。方便 SEO 和 Telegram 等平台预览。

感谢 @septs